### PR TITLE
Fix broken children check

### DIFF
--- a/extension/scripts/DataExtractor.js
+++ b/extension/scripts/DataExtractor.js
@@ -38,7 +38,7 @@ DataExtractor.prototype = {
 		// Link selectors which will follow to a new page also cannot be common 
 		// to all selectors
 		if (selector.canCreateNewJobs()
-			&& this.sitemap.getDirectChildSelectors(selector.id) > 0) {
+			&& this.sitemap.getDirectChildSelectors(selector.id).length > 0) {
 			return false;
 		}
 


### PR DESCRIPTION
Previous expression always returned false (comparing array with 0) and broke any sitemap with a recursive link selector
